### PR TITLE
feat(authentik): add hardened authentik SSO stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This repository contains production-ready Docker Compose configurations with har
 
 ### Security & Authentication
 
+- **[authentik](authentik/)** - Identity provider and SSO (OAuth2/OIDC, SAML, LDAP) with PostgreSQL backend
 - **[vaultwarden](vaultwarden/)** - Self-hosted Bitwarden password manager with PostgreSQL backend
 
 ### Communication

--- a/authentik/.env.example
+++ b/authentik/.env.example
@@ -1,0 +1,24 @@
+# authentik Configuration
+# Copy this file to .env and customize the values for your deployment.
+
+# PostgreSQL
+POSTGRES_DB=authentik
+POSTGRES_USER=authentik
+# Generate: openssl rand -base64 36
+POSTGRES_PASSWORD='CHANGEME'
+
+# authentik
+# Generate: openssl rand -base64 64
+AUTHENTIK_SECRET_KEY='CHANGEME'
+
+# Volume mappings (host source -> container target)
+# Source dirs must be owned by the container users before first start:
+#   postgresql -> 999:999   |   server/worker (data, certs, templates) -> 568:568
+VOLUME_DB_SRC='/mnt/ssd/appdata/authentik/db'
+VOLUME_DB_DST=/var/lib/postgresql/data
+VOLUME_DATA_SRC='/mnt/hdd/appdata/authentik/data'
+VOLUME_DATA_DST=/data
+VOLUME_CERTS_SRC='/mnt/hdd/appdata/authentik/certs'
+VOLUME_CERTS_DST=/certs
+VOLUME_TEMPLATES_SRC='/mnt/hdd/appdata/authentik/custom-templates'
+VOLUME_TEMPLATES_DST=/templates

--- a/authentik/README.md
+++ b/authentik/README.md
@@ -1,0 +1,47 @@
+# authentik
+
+Identity provider / SSO. Adapted from the vendor `compose.yml` to this repo's
+security and infrastructure conventions.
+
+## Changes from the vendor default
+
+- **Hardened all services**: `cap_drop: [ALL]`, `security_opt: [no-new-privileges]`,
+  explicit non-root users (`999:999` for postgres, `568:568` for server/worker).
+- **Dropped the Docker socket integration**: the worker no longer mounts
+  `/var/run/docker.sock` and no longer runs as `root`. authentik can no longer
+  auto-deploy outpost containers on the host — run outposts as standalone
+  containers, or use the embedded proxy outpost inside the server.
+- **No published host ports**: the server is reached only over the external
+  `reverse-proxy` network (port `9000`) via the reverse proxy. TLS is terminated
+  at the proxy, so authentik's own `9443` listener is unused.
+- **Bind mounts** via `VOLUME_*_SRC/DST` env vars instead of a named volume.
+- Postgres pinned to `17.10-alpine3.22` (repo standard); explicit healthchecks.
+
+> Note: current authentik no longer requires Redis — it is not part of this stack.
+
+## First-time setup
+
+```bash
+cd authentik
+
+# Create the bind-mount directories with the correct ownership.
+# DB lives on SSD, everything else on HDD (matches this repo's layout).
+sudo mkdir -p /mnt/ssd/appdata/authentik/db
+sudo mkdir -p /mnt/hdd/appdata/authentik/{data,certs,custom-templates}
+sudo chown -R 999:999 /mnt/ssd/appdata/authentik/db
+sudo chown -R 568:568 /mnt/hdd/appdata/authentik/{data,certs,custom-templates}
+
+docker compose config   # validate
+docker compose up -d
+```
+
+Then create the initial admin account at:
+
+```text
+https://<your-authentik-host>/if/flow/initial-setup/
+```
+
+## Reverse proxy
+
+Point your reverse proxy (zoraxy / nginx-proxy-manager) at the `server`
+container on port `9000` over the `reverse-proxy` network.

--- a/authentik/docker-compose.yml
+++ b/authentik/docker-compose.yml
@@ -1,0 +1,119 @@
+name: authentik
+services:
+  postgresql:
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges
+    user: "999:999"
+    image: docker.io/library/postgres:18.4-alpine3.24@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+    restart: unless-stopped
+    environment:
+      TZ: Europe/Berlin
+      POSTGRES_DB: "${POSTGRES_DB}"
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+    healthcheck:
+      interval: 10s
+      retries: 30
+      start_period: 10s
+      test: pg_isready -h 127.0.0.1 -p 5432 -U $$POSTGRES_USER -d $$POSTGRES_DB
+      timeout: 5s
+    volumes:
+      - type: bind
+        source: ${VOLUME_DB_SRC}
+        target: ${VOLUME_DB_DST}
+        read_only: false
+    networks:
+      - authentik
+
+  authentik:
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges
+    user: "568:568"
+    image: ghcr.io/goauthentik/server:2026.5.4@sha256:a8e80071e5938cca7c8d03461a56740041f274d721100974e042b6d265001f50
+    command: server
+    restart: unless-stopped
+    shm_size: 512mb
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    environment:
+      TZ: Europe/Berlin
+      AUTHENTIK_POSTGRESQL__HOST: postgresql
+      AUTHENTIK_POSTGRESQL__NAME: "${POSTGRES_DB}"
+      AUTHENTIK_POSTGRESQL__USER: "${POSTGRES_USER}"
+      AUTHENTIK_POSTGRESQL__PASSWORD: "${POSTGRES_PASSWORD}"
+      AUTHENTIK_SECRET_KEY: "${AUTHENTIK_SECRET_KEY}"
+      AUTHENTIK_ERROR_REPORTING__ENABLED: "false"
+      AUTHENTIK_DISABLE_UPDATE_CHECK: "true"
+    healthcheck:
+      interval: 10s
+      retries: 30
+      start_period: 60s
+      test: ["CMD", "ak", "healthcheck"]
+      timeout: 5s
+    volumes:
+      - type: bind
+        source: ${VOLUME_DATA_SRC}
+        target: ${VOLUME_DATA_DST}
+        read_only: false
+      - type: bind
+        source: ${VOLUME_TEMPLATES_SRC}
+        target: ${VOLUME_TEMPLATES_DST}
+        read_only: false
+    networks:
+      - authentik
+      - reverse-proxy
+
+  worker:
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges
+    user: "568:568"
+    image: ghcr.io/goauthentik/server:2026.5.4@sha256:a8e80071e5938cca7c8d03461a56740041f274d721100974e042b6d265001f50
+    command: worker
+    restart: unless-stopped
+    shm_size: 512mb
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    environment:
+      TZ: Europe/Berlin
+      AUTHENTIK_POSTGRESQL__HOST: postgresql
+      AUTHENTIK_POSTGRESQL__NAME: "${POSTGRES_DB}"
+      AUTHENTIK_POSTGRESQL__USER: "${POSTGRES_USER}"
+      AUTHENTIK_POSTGRESQL__PASSWORD: "${POSTGRES_PASSWORD}"
+      AUTHENTIK_SECRET_KEY: "${AUTHENTIK_SECRET_KEY}"
+      AUTHENTIK_ERROR_REPORTING__ENABLED: "false"
+      AUTHENTIK_DISABLE_UPDATE_CHECK: "true"
+    healthcheck:
+      interval: 10s
+      retries: 30
+      start_period: 60s
+      test: ["CMD", "ak", "healthcheck"]
+      timeout: 5s
+    volumes:
+      - type: bind
+        source: ${VOLUME_DATA_SRC}
+        target: ${VOLUME_DATA_DST}
+        read_only: false
+      - type: bind
+        source: ${VOLUME_CERTS_SRC}
+        target: ${VOLUME_CERTS_DST}
+        read_only: false
+      - type: bind
+        source: ${VOLUME_TEMPLATES_SRC}
+        target: ${VOLUME_TEMPLATES_DST}
+        read_only: false
+    networks:
+      - authentik
+
+networks:
+  authentik:
+  reverse-proxy:
+    external: true
+    name: reverse-proxy


### PR DESCRIPTION
## Summary

Adds [authentik](https://goauthentik.io/) (identity provider / SSO) as a new service, adapted from the vendor `compose.yml` to this repo's security and infrastructure conventions.

## Changes

- **Hardened all services**: `cap_drop: [ALL]`, `security_opt: [no-new-privileges]`, explicit non-root users (`999:999` postgres, `568:568` server/worker).
- **Dropped the Docker socket integration**: worker no longer mounts `/var/run/docker.sock` or runs as `root` — runs rootless. Outposts must run standalone or via the embedded proxy outpost.
- **No published host ports**: server reachable only over the external `reverse-proxy` network (port `9000`); TLS terminated at the proxy.
- **Digest-pinned images** (`tag@sha256:…`) using multi-arch index digests.
- **SSD/HDD volume split**: DB on `/mnt/ssd/appdata/authentik`, rest on `/mnt/hdd/appdata/authentik`, via `VOLUME_*_SRC/DST`.
- **Postgres 18** (mount point `/var/lib/postgresql`, matching the pg18 image layout).
- Adds `.env.example` + `README.md`; lists the service under **Security & Authentication** in the root README.

## Notes

- Current authentik no longer requires Redis, so it is not part of this stack.
- Bind-mount dirs must be pre-created and chowned before first start (see `authentik/README.md`).