### PR TITLE
feat(paperless-ai): add hardened paperless-ai stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository contains production-ready Docker Compose configurations with har
 - **[collabora](collabora/)** - Online office suite integration for Nextcloud
 - **[n8n](n8n/)** - Workflow automation platform with PostgreSQL backend
 - **[paperless-ngx](paperless-ngx/)** - Document management system with OCR, PostgreSQL, Valkey, Gotenberg, and Tika
+- **[paperless-ai](paperless-ai/)** - AI-powered automatic tagging, classification, and RAG semantic search for paperless-ngx
 
 ### Media & Entertainment
 

--- a/paperless-ai/.env.example
+++ b/paperless-ai/.env.example
@@ -1,0 +1,11 @@
+# paperless-ai Configuration
+# Copy this file to .env and customize the values for your deployment.
+
+# Port the web UI / API listens on inside the container (reached via reverse proxy).
+PAPERLESS_AI_PORT=3000
+
+# Volume mapping (host source -> container target)
+# Source dir must be owned by the container user (568:568) before first start.
+# Holds the SQLite config DB and the RAG vector store, so it lives on SSD.
+VOLUME_DATA_SRC='/mnt/ssd/appdata/paperless-ai/data'
+VOLUME_DATA_DST=/app/data

--- a/paperless-ai/README.md
+++ b/paperless-ai/README.md
@@ -1,0 +1,59 @@
+# paperless-ai
+
+AI-powered document tagging and semantic search for
+[paperless-ngx](../paperless-ngx). Watches paperless for new documents,
+analyzes them with an LLM (OpenAI / Ollama / DeepSeek / any OpenAI-compatible
+backend) and assigns title, tags, document type and correspondent — plus a
+RAG-powered chat over your archive.
+
+Upstream: <https://github.com/clusterzx/paperless-ai>
+
+> **Note:** upstream is currently in maintenance limbo (the author is rewriting
+> the codebase and paperless-ngx is gaining its own AI integration). Pinned to
+> `3.0.9`, the last tagged release.
+
+## Changes from the vendor default
+
+- **Hardened**: `cap_drop: [ALL]`, `security_opt: [no-new-privileges]`, runs as
+  non-root `568:568`. The image ships no privilege-dropping entrypoint, so
+  `HOME`/`PM2_HOME` are pointed at the writable data volume for the PM2 runtime,
+  and `/app/logs` (a hardcoded, root-owned path in the image) is backed by a
+  `tmpfs` so the non-root user can write to it. App logs still stream to
+  `docker compose logs` via pm2's stdout.
+- **No published host ports**: reached only over the external `reverse-proxy`
+  network (port `3000`) via the reverse proxy — no `-p 3000:3000`.
+- **Bind mount** via `VOLUME_DATA_SRC/DST` instead of a named volume. The data
+  dir holds the SQLite config DB and the RAG vector store, so it lives on SSD.
+- **Image pinned** by tag + digest.
+
+The bundled Python RAG service (listens on `127.0.0.1:8000` inside the
+container) stays enabled via `RAG_SERVICE_ENABLED=true`.
+
+## First-time setup
+
+```bash
+cd paperless-ai
+
+# Create the bind-mount dir with the correct ownership.
+sudo mkdir -p /mnt/ssd/appdata/paperless-ai/data
+sudo chown -R 568:568 /mnt/ssd/appdata/paperless-ai/data
+
+docker compose config   # validate
+docker compose up -d
+```
+
+Then open the setup wizard through your reverse proxy and configure:
+
+- **Paperless-ngx connection** — API URL `https://paperless.pc-ziegert.de/api`
+  and an API token (paperless-ngx → *Settings → My Profile → API Token*).
+- **AI provider** — OpenAI / Ollama / DeepSeek / custom OpenAI-compatible
+  endpoint, model and key.
+
+All of this is stored in the data volume, so it survives restarts and image
+updates — nothing sensitive needs to live in `.env`.
+
+## Reverse proxy
+
+Point your reverse proxy (zoraxy / nginx-proxy-manager) at the `paperless-ai`
+container on port `3000` over the `reverse-proxy` network. TLS is terminated at
+the proxy.

--- a/paperless-ai/docker-compose.yml
+++ b/paperless-ai/docker-compose.yml
@@ -1,0 +1,42 @@
+name: paperless-ai
+services:
+  paperless-ai:
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges
+    user: "568:568"
+    image: docker.io/clusterzx/paperless-ai:3.0.9@sha256:2b65888163fd59716f1c8285b31c5bd0b30c9c3c192c42b516688e3887d4ba60
+    restart: unless-stopped
+    environment:
+      TZ: Europe/Berlin
+      PAPERLESS_AI_PORT: "${PAPERLESS_AI_PORT}"
+      RAG_SERVICE_URL: http://localhost:8000
+      RAG_SERVICE_ENABLED: "true"
+      # PM2 and the Node runtime need a writable HOME; point it at the data volume
+      # since the image ships no privilege-dropping entrypoint (runs as 568:568).
+      HOME: ${VOLUME_DATA_DST}
+      PM2_HOME: ${VOLUME_DATA_DST}/.pm2
+    healthcheck:
+      interval: 10s
+      retries: 30
+      start_period: 60s
+      test: "curl --silent --output /dev/null --show-error --fail http://127.0.0.1:${PAPERLESS_AI_PORT}/health"
+      timeout: 5s
+    volumes:
+      - type: bind
+        source: ${VOLUME_DATA_SRC}
+        target: ${VOLUME_DATA_DST}
+        read_only: false
+      # The app hardcodes its log dir to ./logs (/app/logs), which is root-owned
+      # in the image. Give the non-root user a writable, ephemeral mount here;
+      # logs still stream to `docker compose logs` via pm2's stdout.
+      - type: tmpfs
+        target: /app/logs
+    networks:
+      - reverse-proxy
+
+networks:
+  reverse-proxy:
+    external: true
+    name: reverse-proxy


### PR DESCRIPTION
## Summary

Adds [paperless-ai](https://github.com/clusterzx/paperless-ai) — AI-powered automatic tagging, classification, and RAG semantic search for paperless-ngx.

## Details

- **Hardened** to repo conventions: `cap_drop: [ALL]`, `security_opt: [no-new-privileges]`, non-root `568:568`.
- **Image pinned** to `clusterzx/paperless-ai:3.0.9` by digest (last tagged release; upstream is in maintenance limbo).
- **No published host ports** — reached only over the external `reverse-proxy` network on port `3000`.
- **Bind mount** via `VOLUME_DATA_SRC/DST` (SSD — holds the SQLite config DB and RAG vector store).
- **Non-root fixups**: the image ships no privilege-dropping entrypoint, so `HOME`/`PM2_HOME` point at the writable data volume and `/app/logs` (a hardcoded, root-owned path) is backed by a `tmpfs`. Logs still stream to `docker compose logs` via pm2's stdout.
- Adds `README.md` + `.env.example`, and lists the service in the top-level README.

## Configuration

Paperless-ngx connection (API URL + token) and the AI provider/model/key are set through the first-run web setup wizard and persist in the data volume — nothing sensitive lives in `.env`.